### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/heatherleescleaningbusiness/95a63d8a-b9f6-4d65-8177-fb9ee242fc44/0fa732f3-378d-4e1d-a784-4d5acad9eced/_apis/work/boardbadge/75619957-fd13-4ff5-befe-eb46b07ad92b)](https://dev.azure.com/heatherleescleaningbusiness/95a63d8a-b9f6-4d65-8177-fb9ee242fc44/_boards/board/t/0fa732f3-378d-4e1d-a784-4d5acad9eced/Microsoft.RequirementCategory)
 # dotnetfoundation-website
 
 ***NOTE***: This repository is no longer being used to build the dotnetfoundation.org website! The new [site](https://dotnetfoundation.org/) is hosted in a Content Management System (CMS) and is no longer built from this repository.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.